### PR TITLE
Fix Trakt.tv support for Trakt Web v3

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Debrid Media Manager
 // @namespace    https://debridmediamanager.com
-// @version      1.8.1
+// @version      1.8.2
 // @description  Add accessible DMM buttons to IMDB, MDBList, TraktTV, JustWatch, TheTVDB, Criticker, Metacritic, and Bittorrent sites with magnet links
 // @author       Ben Adrian Sarmiento <me@bensarmiento.com>
 // @license      MIT
@@ -195,22 +195,163 @@
 		changeObserver("div.ui.centered.cards", addButtonsToMDBListSearchResults);
 	}
 
-	// TraktTV functions
-	function addButtonsToTraktTVSingleTitle() {
-		const targetElement = document.querySelector("#summary-wrapper div > h1");
+	// TraktTV functions — supports classic (#summary-wrapper) and Trakt Web v3
+	// (Svelte SPA: h1.trakt-responsive-title; IMDb often only in details drawer / API JSON).
+	const TRAKT_EXCLUDED =
+		/^\/(shows|movies)\/(trending|popular|anticipated|recommended|boxoffice|watched|collected|favorited|search)(\/|$)/;
 
-		if (targetElement && targetElement.hasAttribute("data-dmm-btn-added"))
-			return;
-		// find imdb id in page, <a data-type="imdb">
-		const imdbId = document
-			.querySelector("a#external-link-imdb")
-			?.href?.match(/tt\d+/)?.[0];
+	function getTraktSlugPath() {
+		// /movies/foo-2024 or /shows/bar[/seasons/1]
+		const m = location.pathname.match(
+			/^\/(movies|shows)\/([^/]+)(?:\/|$)/
+		);
+		if (!m || TRAKT_EXCLUDED.test(location.pathname)) return null;
+		return { type: m[1], slug: m[2] };
+	}
+
+	function findTraktImdbId() {
+		const selectors = [
+			"a#external-link-imdb",
+			'a[href*="imdb.com/title/"]',
+			'a[href*="www.imdb.com/title/"]',
+		];
+		for (const sel of selectors) {
+			const id = document.querySelector(sel)?.href?.match(/tt\d+/)?.[0];
+			if (id) return id;
+		}
+		// Page/API payloads sometimes leave ids in text/scripts
+		const html = document.documentElement?.innerHTML || "";
+		const fromJson =
+			html.match(/"imdb(?:Id)?"\s*:\s*"(tt\d+)"/) ||
+			html.match(/imdb\.com\/title\/(tt\d+)/);
+		if (fromJson) return fromJson[1];
+		return window.__DMM_TRAKT_IMDB || null;
+	}
+
+	function findTraktTitleElement() {
+		return (
+			document.querySelector("#summary-wrapper div > h1") ||
+			document.querySelector("h1.trakt-responsive-title") ||
+			document.querySelector('[data-testid="summary-media-title"]') ||
+			document.querySelector(".trakt-summary-title h1") ||
+			document.querySelector("h1")
+		);
+	}
+
+	function injectTraktFetchHook() {
+		if (document.documentElement.hasAttribute("data-dmm-trakt-hook")) return;
+		document.documentElement.setAttribute("data-dmm-trakt-hook", "1");
+		const script = document.createElement("script");
+		script.textContent = `(${function () {
+			if (window.__DMM_TRAKT_HOOK__) return;
+			window.__DMM_TRAKT_HOOK__ = true;
+			const post = (imdb) => {
+				if (!imdb || !/^tt\d+$/.test(imdb)) return;
+				window.postMessage({ source: "dmm-trakt", imdbId: imdb }, "*");
+			};
+			const scrape = (data) => {
+				if (!data || typeof data !== "object") return;
+				const id =
+					data.ids?.imdb ||
+					data.imdbId ||
+					data.movie?.ids?.imdb ||
+					data.show?.ids?.imdb ||
+					data.episode?.ids?.imdb;
+				if (id) post(id);
+			};
+			const wrap = (orig) =>
+				function (...args) {
+					const p = orig.apply(this, args);
+					try {
+						const req = args[0];
+						const url =
+							typeof req === "string"
+								? req
+								: req && req.url
+									? req.url
+									: "";
+						if (
+							url &&
+							/\/(movies|shows)\//.test(url) &&
+							!/\/(related|comments|lists|people|stats|ratings|videos|watching|watched|collection)/.test(
+								url
+							)
+						) {
+							p.then((res) => {
+								try {
+									res
+										.clone()
+										.json()
+										.then(scrape)
+										.catch(() => {});
+								} catch (_) {}
+							}).catch(() => {});
+						}
+					} catch (_) {}
+					return p;
+				};
+			if (window.fetch) window.fetch = wrap(window.fetch.bind(window));
+		}})()`;
+		(document.head || document.documentElement).appendChild(script);
+		script.remove();
+	}
+
+	function addButtonsToTraktTVSingleTitle() {
+		if (/\/episodes\/\d/.test(location.pathname)) return;
+		if (!getTraktSlugPath()) return;
+
+		injectTraktFetchHook();
+
+		const targetElement = findTraktTitleElement();
+		if (!targetElement) return;
+		if (targetElement.hasAttribute("data-dmm-btn-added")) return;
+
+		const imdbId = findTraktImdbId();
 		if (!imdbId) return;
 
 		targetElement.setAttribute("data-dmm-btn-added", "true");
-
 		const searchUrl = `${X_DMM_HOST}/${imdbId}`;
 		addButtonToElement(targetElement, SEARCH_BTN_LABEL, searchUrl);
+	}
+
+	function setupTraktTV() {
+		injectTraktFetchHook();
+		window.addEventListener("message", (event) => {
+			if (event.source !== window) return;
+			const data = event.data;
+			if (!data || data.source !== "dmm-trakt" || !data.imdbId) return;
+			window.__DMM_TRAKT_IMDB = data.imdbId;
+			document
+				.querySelectorAll("[data-dmm-btn-added]")
+				.forEach((el) => el.removeAttribute("data-dmm-btn-added"));
+			addButtonsToTraktTVSingleTitle();
+		});
+
+		const run = () => addButtonsToTraktTVSingleTitle();
+		run();
+		changeObserver("body", run);
+
+		// SPA navigations (Trakt Web v3)
+		const rewipe = () => {
+			window.__DMM_TRAKT_IMDB = null;
+			document
+				.querySelectorAll("[data-dmm-btn-added]")
+				.forEach((el) => el.removeAttribute("data-dmm-btn-added"));
+			setTimeout(run, 200);
+			setTimeout(run, 1000);
+			setTimeout(run, 2500);
+		};
+		const wrapHist = (method) => {
+			const orig = history[method];
+			history[method] = function (...args) {
+				const ret = orig.apply(this, args);
+				rewipe();
+				return ret;
+			};
+		};
+		wrapHist("pushState");
+		wrapHist("replaceState");
+		window.addEventListener("popstate", rewipe);
 	}
 
 	// iCheckMovies functions
@@ -407,14 +548,7 @@
 
 		///// TRAKT TV /////
 	} else if (hostname === "trakt.tv") {
-		const isTraktTVEpisodePage = /\/episodes\/\d/.test(location.pathname);
-		if (isTraktTVEpisodePage) return;
-
-		const isTraktTVSinglePage = /^\/(shows|movies)\/.+/.test(location.pathname);
-
-		if (isTraktTVSinglePage) {
-			addButtonsToTraktTVSingleTitle();
-		}
+		setupTraktTV();
 
 		///// ICHECKMOVIES /////
 	} else if (hostname === "www.icheckmovies.com") {

--- a/content_script.js
+++ b/content_script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Debrid Media Manager
 // @namespace    https://debridmediamanager.com
-// @version      1.8.2
+// @version      1.8.3
 // @description  Add accessible DMM buttons to IMDB, MDBList, TraktTV, JustWatch, TheTVDB, Criticker, Metacritic, and Bittorrent sites with magnet links
 // @author       Ben Adrian Sarmiento <me@bensarmiento.com>
 // @license      MIT
@@ -195,31 +195,34 @@
 		changeObserver("div.ui.centered.cards", addButtonsToMDBListSearchResults);
 	}
 
-	// TraktTV functions — supports classic (#summary-wrapper) and Trakt Web v3
-	// (Svelte SPA: h1.trakt-responsive-title; IMDb often only in details drawer / API JSON).
+	// TraktTV — classic UI + Trakt Web v3 (app.trakt.tv Svelte SPA)
 	const TRAKT_EXCLUDED =
 		/^\/(shows|movies)\/(trending|popular|anticipated|recommended|boxoffice|watched|collected|favorited|search)(\/|$)/;
 
-	function getTraktSlugPath() {
-		// /movies/foo-2024 or /shows/bar[/seasons/1]
-		const m = location.pathname.match(
-			/^\/(movies|shows)\/([^/]+)(?:\/|$)/
+	function isTraktHost(hostname) {
+		return (
+			hostname === "trakt.tv" ||
+			hostname === "www.trakt.tv" ||
+			hostname === "app.trakt.tv"
 		);
+	}
+
+	function getTraktSlugPath() {
+		const m = location.pathname.match(/^\/(movies|shows)\/([^/]+)(?:\/|$)/);
 		if (!m || TRAKT_EXCLUDED.test(location.pathname)) return null;
-		return { type: m[1], slug: m[2] };
+		return { type: m[1], slug: decodeURIComponent(m[2]) };
 	}
 
 	function findTraktImdbId() {
 		const selectors = [
 			"a#external-link-imdb",
+			'.trakt-summary-ratings a[href*="imdb.com/title/"]',
 			'a[href*="imdb.com/title/"]',
-			'a[href*="www.imdb.com/title/"]',
 		];
 		for (const sel of selectors) {
 			const id = document.querySelector(sel)?.href?.match(/tt\d+/)?.[0];
 			if (id) return id;
 		}
-		// Page/API payloads sometimes leave ids in text/scripts
 		const html = document.documentElement?.innerHTML || "";
 		const fromJson =
 			html.match(/"imdb(?:Id)?"\s*:\s*"(tt\d+)"/) ||
@@ -230,100 +233,58 @@
 
 	function findTraktTitleElement() {
 		return (
-			document.querySelector("#summary-wrapper div > h1") ||
 			document.querySelector("h1.trakt-responsive-title") ||
 			document.querySelector('[data-testid="summary-media-title"]') ||
 			document.querySelector(".trakt-summary-title h1") ||
+			document.querySelector("#summary-wrapper div > h1") ||
 			document.querySelector("h1")
 		);
 	}
 
-	function injectTraktFetchHook() {
-		if (document.documentElement.hasAttribute("data-dmm-trakt-hook")) return;
-		document.documentElement.setAttribute("data-dmm-trakt-hook", "1");
-		const script = document.createElement("script");
-		script.textContent = `(${function () {
-			if (window.__DMM_TRAKT_HOOK__) return;
-			window.__DMM_TRAKT_HOOK__ = true;
-			const post = (imdb) => {
-				if (!imdb || !/^tt\d+$/.test(imdb)) return;
-				window.postMessage({ source: "dmm-trakt", imdbId: imdb }, "*");
-			};
-			const scrape = (data) => {
-				if (!data || typeof data !== "object") return;
-				const id =
-					data.ids?.imdb ||
-					data.imdbId ||
-					data.movie?.ids?.imdb ||
-					data.show?.ids?.imdb ||
-					data.episode?.ids?.imdb;
-				if (id) post(id);
-			};
-			const wrap = (orig) =>
-				function (...args) {
-					const p = orig.apply(this, args);
-					try {
-						const req = args[0];
-						const url =
-							typeof req === "string"
-								? req
-								: req && req.url
-									? req.url
-									: "";
-						if (
-							url &&
-							/\/(movies|shows)\//.test(url) &&
-							!/\/(related|comments|lists|people|stats|ratings|videos|watching|watched|collection)/.test(
-								url
-							)
-						) {
-							p.then((res) => {
-								try {
-									res
-										.clone()
-										.json()
-										.then(scrape)
-										.catch(() => {});
-								} catch (_) {}
-							}).catch(() => {});
-						}
-					} catch (_) {}
-					return p;
-				};
-			if (window.fetch) window.fetch = wrap(window.fetch.bind(window));
-		}})()`;
-		(document.head || document.documentElement).appendChild(script);
-		script.remove();
+	function traktDmmUrl(imdbId, title) {
+		if (imdbId) return `${X_DMM_HOST}/${imdbId}`;
+		const q = (title || "").trim();
+		if (!q) return DMM_HOST;
+		return `${DMM_HOST}/?search=${encodeURIComponent(q)}`;
 	}
 
 	function addButtonsToTraktTVSingleTitle() {
 		if (/\/episodes\/\d/.test(location.pathname)) return;
 		if (!getTraktSlugPath()) return;
 
-		injectTraktFetchHook();
-
 		const targetElement = findTraktTitleElement();
 		if (!targetElement) return;
-		if (targetElement.hasAttribute("data-dmm-btn-added")) return;
 
 		const imdbId = findTraktImdbId();
-		if (!imdbId) return;
+		const title = (targetElement.textContent || "").trim();
+		const searchUrl = traktDmmUrl(imdbId, title);
+
+		// Always show a button once we have a title; upgrade href when IMDb arrives
+		let btn = targetElement.querySelector("button[data-dmm-trakt-btn]");
+		if (btn) {
+			if (imdbId && !btn.dataset.dmmImdb) {
+				btn.dataset.dmmImdb = imdbId;
+				btn.onclick = (event) => {
+					event.preventDefault();
+					window.open(searchUrl, "_blank");
+				};
+			}
+			return;
+		}
 
 		targetElement.setAttribute("data-dmm-btn-added", "true");
-		const searchUrl = `${X_DMM_HOST}/${imdbId}`;
-		addButtonToElement(targetElement, SEARCH_BTN_LABEL, searchUrl);
+		btn = createButton(SEARCH_BTN_LABEL, searchUrl);
+		btn.setAttribute("data-dmm-trakt-btn", "1");
+		if (imdbId) btn.dataset.dmmImdb = imdbId;
+		targetElement.appendChild(btn);
 	}
 
 	function setupTraktTV() {
-		injectTraktFetchHook();
 		window.addEventListener("message", (event) => {
 			if (event.source !== window) return;
 			const data = event.data;
 			if (!data || data.source !== "dmm-trakt" || !data.imdbId) return;
 			window.__DMM_TRAKT_IMDB = data.imdbId;
-			document
-				.querySelectorAll("[data-dmm-btn-added]")
-				.forEach((el) => el.removeAttribute("data-dmm-btn-added"));
 			addButtonsToTraktTVSingleTitle();
 		});
 
@@ -331,15 +292,20 @@
 		run();
 		changeObserver("body", run);
 
-		// SPA navigations (Trakt Web v3)
 		const rewipe = () => {
 			window.__DMM_TRAKT_IMDB = null;
 			document
-				.querySelectorAll("[data-dmm-btn-added]")
-				.forEach((el) => el.removeAttribute("data-dmm-btn-added"));
-			setTimeout(run, 200);
-			setTimeout(run, 1000);
-			setTimeout(run, 2500);
+				.querySelectorAll("[data-dmm-btn-added], button[data-dmm-trakt-btn]")
+				.forEach((el) => {
+					if (el.tagName === "BUTTON" && el.hasAttribute("data-dmm-trakt-btn")) {
+						el.remove();
+					} else {
+						el.removeAttribute("data-dmm-btn-added");
+					}
+				});
+			setTimeout(run, 150);
+			setTimeout(run, 800);
+			setTimeout(run, 2000);
 		};
 		const wrapHist = (method) => {
 			const orig = history[method];
@@ -547,7 +513,7 @@
 		}
 
 		///// TRAKT TV /////
-	} else if (hostname === "trakt.tv") {
+	} else if (isTraktHost(hostname)) {
 		setupTraktTV();
 
 		///// ICHECKMOVIES /////

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,21 @@
 {
     "manifest_version": 3,
     "name": "Debrid Media Manager",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "description": "Add DMM buttons to IMDB, MDBList, TraktTV, Letterboxd, JustWatch, TheTVDB, Criticker, Metacritic, and torrent sites",
     "content_scripts": [
+        {
+            "matches": [
+                "*://trakt.tv/*",
+                "*://www.trakt.tv/*",
+                "*://app.trakt.tv/*"
+            ],
+            "js": [
+                "trakt_page_hook.js"
+            ],
+            "run_at": "document_start",
+            "world": "MAIN"
+        },
         {
             "matches": [
                 "<all_urls>"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Debrid Media Manager",
-    "version": "1.8.0",
+    "version": "1.8.2",
     "description": "Add DMM buttons to IMDB, MDBList, TraktTV, Letterboxd, JustWatch, TheTVDB, Criticker, Metacritic, and torrent sites",
     "content_scripts": [
         {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.0",
+  "version": "1.8.2",
   "scripts": {
     "prepare": "pre-commit install || echo 'pre-commit not found — install it with: uv tool install pre-commit'",
     "screenshots": "node scripts/screenshots.js"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.2",
+  "version": "1.8.3",
   "scripts": {
     "prepare": "pre-commit install || echo 'pre-commit not found — install it with: uv tool install pre-commit'",
     "screenshots": "node scripts/screenshots.js"

--- a/tests/trakt-cdp.spec.js
+++ b/tests/trakt-cdp.spec.js
@@ -26,9 +26,12 @@ test.describe("Trakt.tv (CDP)", () => {
 			await page.goto("https://trakt.tv/shows/fallout", {
 				waitUntil: "domcontentloaded",
 			});
-			await page.waitForSelector("#summary-wrapper div > h1", {
-				timeout: 30_000,
-			});
+			await page.waitForSelector(
+				"h1.trakt-responsive-title, #summary-wrapper div > h1, [data-testid='summary-media-title']",
+				{
+					timeout: 30_000,
+				}
+			);
 			const btns = await injectAndWaitForButtons(page);
 			await expect(btns).toHaveCount(1);
 
@@ -50,9 +53,12 @@ test.describe("Trakt.tv (CDP)", () => {
 				"https://trakt.tv/movies/ghostbusters-frozen-empire-2024",
 				{ waitUntil: "domcontentloaded" }
 			);
-			await page.waitForSelector("#summary-wrapper div > h1", {
-				timeout: 30_000,
-			});
+			await page.waitForSelector(
+				"h1.trakt-responsive-title, #summary-wrapper div > h1, [data-testid='summary-media-title']",
+				{
+					timeout: 30_000,
+				}
+			);
 			const btns = await injectAndWaitForButtons(page);
 			await expect(btns).toHaveCount(1);
 
@@ -74,9 +80,12 @@ test.describe("Trakt.tv (CDP)", () => {
 				"https://trakt.tv/shows/shogun-2024/seasons/1/episodes/1",
 				{ waitUntil: "domcontentloaded" }
 			);
-			await page.waitForSelector("#summary-wrapper div > h1", {
-				timeout: 30_000,
-			});
+			await page.waitForSelector(
+				"h1.trakt-responsive-title, #summary-wrapper div > h1, [data-testid='summary-media-title']",
+				{
+					timeout: 30_000,
+				}
+			);
 			await injectScript(page);
 			await page.waitForTimeout(3_000);
 			const btns = page.locator("[data-dmm-btn-added]");

--- a/tests/trakt-cdp.spec.js
+++ b/tests/trakt-cdp.spec.js
@@ -23,7 +23,7 @@ test.describe("Trakt.tv (CDP)", () => {
 		const context = browser.contexts()[0] || await browser.newContext();
 		const page = await context.newPage();
 		try {
-			await page.goto("https://trakt.tv/shows/fallout", {
+			await page.goto("https://app.trakt.tv/shows/fallout", {
 				waitUntil: "domcontentloaded",
 			});
 			await page.waitForSelector(
@@ -50,7 +50,7 @@ test.describe("Trakt.tv (CDP)", () => {
 		const page = await context.newPage();
 		try {
 			await page.goto(
-				"https://trakt.tv/movies/ghostbusters-frozen-empire-2024",
+				"https://app.trakt.tv/movies/ghostbusters-frozen-empire-2024",
 				{ waitUntil: "domcontentloaded" }
 			);
 			await page.waitForSelector(
@@ -77,7 +77,7 @@ test.describe("Trakt.tv (CDP)", () => {
 		const page = await context.newPage();
 		try {
 			await page.goto(
-				"https://trakt.tv/shows/shogun-2024/seasons/1/episodes/1",
+				"https://app.trakt.tv/shows/shogun-2024/seasons/1/episodes/1",
 				{ waitUntil: "domcontentloaded" }
 			);
 			await page.waitForSelector(

--- a/trakt_page_hook.js
+++ b/trakt_page_hook.js
@@ -1,0 +1,50 @@
+// Runs in page MAIN world at document_start — intercept Trakt API fetches for IMDb ids.
+(function () {
+	"use strict";
+	if (window.__DMM_TRAKT_HOOK__) return;
+	window.__DMM_TRAKT_HOOK__ = true;
+
+	const post = (imdb) => {
+		if (!imdb || !/^tt\d+$/.test(String(imdb))) return;
+		window.postMessage({ source: "dmm-trakt", imdbId: String(imdb) }, "*");
+	};
+
+	const scrape = (data) => {
+		if (!data || typeof data !== "object") return;
+		const id =
+			data.ids?.imdb ||
+			data.imdbId ||
+			data.movie?.ids?.imdb ||
+			data.show?.ids?.imdb ||
+			data.episode?.ids?.imdb;
+		if (id) post(id);
+		if (Array.isArray(data)) data.forEach(scrape);
+	};
+
+	const interesting = (url) =>
+		url &&
+		/\/(movies|shows)\//.test(url) &&
+		!/\/(related|comments|lists|people|stats|videos|watching|watched|collection|translations|studios|seasons\/\d+\/episodes)/.test(
+			url
+		);
+
+	if (window.fetch) {
+		const orig = window.fetch.bind(window);
+		window.fetch = function (...args) {
+			const p = orig(...args);
+			try {
+				const req = args[0];
+				const url =
+					typeof req === "string" ? req : req && req.url ? req.url : "";
+				if (interesting(url)) {
+					p.then((res) => {
+						try {
+							res.clone().json().then(scrape).catch(() => {});
+						} catch (_) {}
+					}).catch(() => {});
+				}
+			} catch (_) {}
+			return p;
+		};
+	}
+})();


### PR DESCRIPTION
## Summary
- Trakt's new Svelte SPA dropped `#summary-wrapper` / `#external-link-imdb`, so the existing Trakt handler silently no-op'd.
- Mount on `h1.trakt-responsive-title` (and legacy selectors), resolve IMDb via links / JSON / page `fetch` hook, and re-run on SPA navigations.
- Bump version to **1.8.2**.

## Test plan
- [ ] Load unpacked build on `https://trakt.tv/movies/...` — DMM button next to title
- [ ] Same for `https://trakt.tv/shows/...`
- [ ] Client-side navigate between titles — button updates
- [ ] Episode pages still skip
- [ ] Classic selectors still work if old markup appears


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Trakt integration across supported title pages.
  * Added support for detecting IMDb IDs from multiple page sources and Trakt API responses.
  * Added reliable button injection during single-page navigation.

* **Bug Fixes**
  * Improved handling of Trakt page types and title layouts.
  * Increased compatibility with changing page structures.

* **Chores**
  * Updated the extension and package version to 1.8.2.
  * Improved automated checks for Trakt page title loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->